### PR TITLE
fix: offload bolt11_decode in list_transactions to worker thread

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -410,7 +410,13 @@ async def _on_list_transactions(
     transactions: list[dict] = []
     p: Payment
     for p in history:
-        invoice_data = bolt11_decode(p.bolt11)
+        # bolt11_decode is synchronous and CPU-bound. Running it directly inside
+        # this async handler blocks the asyncio event loop for the duration of
+        # the whole batch, long enough that NWC clients hit their reply timeout
+        # and other extensions (nostrclient relay keep-alives, publishes,
+        # concurrent requests) are starved. Offload to a worker thread so the
+        # event loop stays responsive.
+        invoice_data = await asyncio.to_thread(bolt11_decode, p.bolt11)
         is_settled = not p.pending
         timestamp = int(p.time.timestamp()) or invoice_data.date
         transactions.append(


### PR DESCRIPTION
> Take the proposed fix with a pinch of salt — drafted quickly with AI assistance. The diagnosis (synchronous `bolt11_decode` blocking the event loop) is grounded in reading the handler code, but the exact fix shape deserves maintainer review.

## Summary

Fixes #35

`_on_list_transactions` in `tasks.py` calls the synchronous `bolt11_decode()` inside a Python `for` loop in an async handler. On wallets with non-trivial history this blocks the asyncio event loop long enough that:

- NWC clients hit their reply timeout (`~60s`) and see `list_transactions` fail
- Relay keep-alives, publish tasks, and concurrent NWC requests are starved
- LNbits logs show nothing useful — the handler is simply still running

Other NWC methods (`get_info`, `get_balance`, `make_invoice`, `lookup_invoice`) are unaffected because they don't do per-record synchronous CPU work in a loop.

## Status

> Draft — currently testing this fix in production (LNbits v1.5.3, LNDRest). Will mark ready for review once verified over a sustained period.

## Fix

Offload each `bolt11_decode` call to a worker thread via `asyncio.to_thread`, so the event loop can keep running while each invoice is parsed. This is the same pattern used in lnbits/lnbits#3925 for analogous synchronous websocket calls in `send_nostr_dm`.

```python
# before
invoice_data = bolt11_decode(p.bolt11)

# after
invoice_data = await asyncio.to_thread(bolt11_decode, p.bolt11)
```

`asyncio` is already imported; no new dependencies.

## Why this matters

Together with the other two fixes that are already in production testing, this closes the last of three event-loop-starvation paths that collectively rendered NWC unusable on busy LNDRest-backed wallets:

| Fix | Repo | Path |
|-----|------|------|
| IN_FLIGHT polling hot-loop | lnbits/lnbits#3918 | `lnbits/core/services/payments.py` |
| Blocking relay publishes | lnbits/lnbits#3925 | `lnbits/core/services/nostr.py` |
| **This PR** | lnbits/nwcprovider | `nwcprovider/tasks.py` |

## Alternatives considered

- **Defer decode to the client**: pass raw `bolt11` through and let the client decode. Smaller payload, no server CPU. But it changes the response schema (fields `description`, `description_hash`, and the `invoice_data.date` fallback for `timestamp`) and would break clients that rely on the current shape. Rejected for backward compatibility.
- **Periodic `asyncio.sleep(0)` yields**: works, but still runs all the CPU on the event-loop thread. `asyncio.to_thread` is cleaner and scales better.

## Related

- Fixes #35
- Sibling fixes: lnbits/lnbits#3918, lnbits/lnbits#3925
- Symptom: lnbits/nostrclient#40 (nostrclient unresponsive — same event-loop starvation class)

## Changes

- `tasks.py`: wrap `bolt11_decode` in `asyncio.to_thread` inside `_on_list_transactions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
