### PR TITLE
feat(nwcp): add NIP-42 client AUTH support

### DIFF
--- a/nwcp.py
+++ b/nwcp.py
@@ -508,10 +508,37 @@ class NWCServiceProvider:
                 logger.info("Notice from relay " + self.relay + ": " + str(msg[1]))
             elif msg[0] == "OK":
                 pass
+            elif msg[0] == "AUTH":
+                await self._on_auth_message(msg)
             else:
                 raise Exception("Unknown message type " + str(msg[0]))
         except Exception as e:
             logger.error("Error parsing event: " + str(e))
+
+    async def _on_auth_message(self, msg: list) -> None:
+        """
+        Handle NIP-42 AUTH challenge from the relay (NIP-42).
+
+        When a relay sends ["AUTH", "<challenge>"], we respond with a signed
+        kind-22242 event containing the relay URL and challenge string.
+        See: https://github.com/nostr-protocol/nips/blob/master/42.md
+        """
+        if len(msg) < 2:
+            logger.warning("Received AUTH message without challenge, ignoring")
+            return
+        challenge = msg[1]
+        auth_event: dict = {
+            "kind": 22242,
+            "content": "",
+            "created_at": int(time.time()),
+            "tags": [
+                ["relay", self.relay],
+                ["challenge", challenge],
+            ],
+        }
+        self._sign_event(auth_event)
+        await self._send(["AUTH", auth_event])
+        logger.debug("Sent NIP-42 AUTH response for challenge: " + str(challenge))
 
     async def _connect_to_relay(self):
         """

--- a/nwcp.py
+++ b/nwcp.py
@@ -507,13 +507,46 @@ class NWCServiceProvider:
                 # A message from the relay, mostly useless, but we log it anyway
                 logger.info("Notice from relay " + self.relay + ": " + str(msg[1]))
             elif msg[0] == "OK":
-                pass
+                await self._on_ok_message(msg)
             elif msg[0] == "AUTH":
                 await self._on_auth_message(msg)
             else:
                 raise Exception("Unknown message type " + str(msg[0]))
         except Exception as e:
             logger.error("Error parsing event: " + str(e))
+
+    async def _on_ok_message(self, msg: list) -> None:
+        """Handle relay OK messages and surface rejections for diagnostics."""
+        event_id = str(msg[1]) if len(msg) > 1 else "unknown"
+        accepted = msg[2] if len(msg) > 2 else None
+        relay_msg = str(msg[3]) if len(msg) > 3 else ""
+
+        if accepted is False:
+            logger.warning(
+                "Relay "
+                + self.relay
+                + " rejected event "
+                + event_id
+                + (": " + relay_msg if relay_msg else "")
+            )
+            return
+
+        if accepted is True:
+            logger.debug(
+                "Relay "
+                + self.relay
+                + " accepted event "
+                + event_id
+                + (": " + relay_msg if relay_msg else "")
+            )
+            return
+
+        logger.debug(
+            "Received malformed OK message from relay "
+            + self.relay
+            + ": "
+            + str(msg)
+        )
 
     async def _on_auth_message(self, msg: list) -> None:
         """


### PR DESCRIPTION
## Problem

When a NIP-42-enabled relay sends `["AUTH", "<challenge>"]`, nwcprovider hits the catch-all `raise Exception("Unknown message type")` branch. The error is logged and no response is sent. The relay closes subscriptions because the challenge is never answered.

This makes nwcprovider completely incompatible with any relay that has `nip42_auth = true`.