### PR TITLE
fix: break _process_invoice wait loop on failed payments

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -110,9 +110,12 @@ async def _process_invoice(
         True  # currently required by nip 47 specs, might change in future
     )
     payment_status: PaymentStatus | None = None
+    deadline = time.monotonic() + 300
     while wait_for_preimage:
         payment_status = await check_transaction_status(wallet_id, payment_hash)
-        if payment_status.success:
+        if payment_status.success or payment_status.failed:
+            break
+        if time.monotonic() > deadline:
             break
         await asyncio.sleep(0.05)
     if not payment_status:


### PR DESCRIPTION
Fixes #39.

`_process_invoice`'s wait loop only exits on `payment_status.success`, so any `.failed` payment loops at ~20 RPS forever. Adds a `.failed` break and a 300 s deadline.