### PR TITLE
list_transactions: fall back to extra.comment / memo when BOLT11 description is empty

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -425,7 +425,20 @@ async def _on_list_transactions(
             {
                 "type": "outgoing" if p.is_out else "incoming",
                 "invoice": p.bolt11,
-                "description": invoice_data.description,
+                # Fallback chain so a human-readable description reaches
+                # the NWC client even for LNURL-pay payments (where the
+                # BOLT11 description is just a SHA-256 hash, not text):
+                #   1. `extra.comment` — LUD-12 payer-supplied message
+                #   2. `invoice_data.description` — BOLT11 description
+                #      when it carries the actual text rather than a hash
+                #   3. `p.memo` — Pay Link item description / generic memo
+                # Mirrors what `_on_lookup_invoice` already does, plus the
+                # LUD-12 source. See #42.
+                "description": (
+                    (p.extra or {}).get("comment")
+                    or invoice_data.description
+                    or p.memo
+                ),
                 "description_hash": invoice_data.description_hash,
                 "preimage": p.preimage if is_settled or p.is_in else None,
                 "payment_hash": p.payment_hash,

--- a/tasks.py
+++ b/tasks.py
@@ -426,14 +426,7 @@ async def _on_list_transactions(
                 "type": "outgoing" if p.is_out else "incoming",
                 "invoice": p.bolt11,
                 # Fallback chain so a human-readable description reaches
-                # the NWC client even for LNURL-pay payments (where the
-                # BOLT11 description is just a SHA-256 hash, not text):
-                #   1. `extra.comment` — LUD-12 payer-supplied message
-                #   2. `invoice_data.description` — BOLT11 description
-                #      when it carries the actual text rather than a hash
-                #   3. `p.memo` — Pay Link item description / generic memo
-                # Mirrors what `_on_lookup_invoice` already does, plus the
-                # LUD-12 source. See #42.
+                # the NWC client. Mirror of `_on_lookup_invoice` 
                 "description": (
                     (p.extra or {}).get("comment")
                     or invoice_data.description


### PR DESCRIPTION
Closes #42.

## Summary

`_on_list_transactions` returns `description: None` for LNURL-pay payments because the BOLT11 `description` is a SHA-256 hash (LUD-06 `description_hash`), not human text. The actual content lives in:

- `payment.extra.comment` — the payer's LUD-12 message
- `payment.memo` — the Pay Link's "Item description"

…both of which `list_transactions` was ignoring. `lookup_invoice` already falls back to `payment.memo`; this PR mirrors that, plus prefers LUD-12 comments when present.

## Change

One field's value, in `tasks.py` `_on_list_transactions`:

```python
"description": (
    (p.extra or {}).get("comment")     # LUD-12 payer-supplied message
    or invoice_data.description        # BOLT11 description (when human text, not hash)
    or p.memo                          # Pay Link item description / generic memo
),
```

Ordering rationale — when a payer typed a message via LUD-12, that's more informative for the receiver than the receiver's own Pay Link template. Falls back through both other sources for non-LUD-12 incoming payments and for outgoing ones, matching the existing `_on_lookup_invoice` shape.

## Test plan

- [x] Read against the divergent `_on_lookup_invoice` body (line ~356) — fallback chain is consistent with what lookup already does, plus the `extra.comment` source.
- [ ] Local LNBits dev env: install the change, send a comment-bearing LUD-12 payment to a Lightning Address, confirm `description` in `list_transactions` response equals the payer's comment string.
- [ ] Same flow with **no** comment: confirm fallback to `invoice_data.description` (if present) or `p.memo`.
- [ ] Outgoing payment (`pay_invoice`): confirm `description` still populates from `invoice_data.description` / `p.memo`.

Happy to run any additional tests the maintainer wants. Verified on Lightning Piggy (ESP32 NWC display wallet, [github.com/LightningPiggy/LightningPiggyApp](https://github.com/LightningPiggy/LightningPiggyApp)) against an LNBits instance: with this change, payer-supplied comments now appear in the on-device transaction list; without it, every LNURL-pay row reads as bare-amount.