### PR TITLE
fix: add EOSE timeout fallback and increase handle_missed_events default

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The configuration page of the NWC Service Provider extension is available at `/n
 | relay                | URL of the nostr relay for dispatching and receiving NWC events. Use public relays or a custom one. Specify `nostrclient` to connect to the [nostrclient extension](https://github.com/lnbits/nostrclient). | nostrclient                     |
 | provider_key         | Nostr secret key of the NWC Service Provider.                                                                                                                                                               | Random key generated on install |
 | relay_alias          | Relay URL to display in pairing URLs. Set if different from `relay`.                                                                                                                                        | Empty (uses the `relay` value)  |
-| handle_missed_events | Number of seconds to look back for processing events missed while offline. Setting it to 0 disables this functionality.                                                                                     | 0                               |
+| handle_missed_events | Number of seconds to look back for processing events missed while offline. Setting it to 0 disables this functionality.                                                                                     | 120                             |
 
 > [!WARNING]
 >

--- a/migrations.py
+++ b/migrations.py
@@ -117,5 +117,5 @@ async def m006_default_config3(db):
         VALUES ('handle_missed_events', :value)
         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
         """,
-        {"value": "0"},
+        {"value": "120"},
     )

--- a/nwcp.py
+++ b/nwcp.py
@@ -124,6 +124,9 @@ class NWCServiceProvider:
         # Periodic info event resend loop
         self.info_event_task = None
 
+        # EOSE timeout task (fallback if relay never sends EOSE)
+        self.eose_timeout_task = None
+
         # Subscription
         self.sub = None
         self.rate_limit: dict[str, RateLimit] = {}
@@ -270,10 +273,43 @@ class NWCServiceProvider:
         await asyncio.sleep(limit.backoff)
         limit.last_attempt_time = int(time.time())
 
+    async def _process_stale_events(self):
+        if not self.sub:
+            return
+        stales = self.sub.get_stale()
+        if not stales:
+            return
+        logger.debug(f"Processing {len(stales)} stale events (EOSE timeout)")
+        for stale in stales:
+            try:
+                await self._handle_request(stale)
+            except Exception as e:
+                logger.error(f"Error handling stale event: {e}")
+
+    async def _eose_timeout(self):
+        await asyncio.sleep(10)
+        if self._is_shutting_down():
+            return
+        if not self.sub:
+            return
+        if not (self.sub.requests_eose and self.sub.responses_eose):
+            logger.warning(
+                "EOSE not received within 10s timeout, "
+                "processing pending events anyway"
+            )
+            self.sub.requests_eose = True
+            self.sub.responses_eose = True
+            await self._process_stale_events()
+
     async def _subscribe(self):
         """
         [Re]Subscribe to receive nip 47 requests and responses from the relay
         """
+        # Cancel previous EOSE timeout if any
+        if self.eose_timeout_task:
+            self.eose_timeout_task.cancel()
+            self.eose_timeout_task = None
+
         self.sub = MainSubscription()
         # Create requests subscription
         req_filter = {
@@ -293,6 +329,8 @@ class NWCServiceProvider:
         # Subscribe
         await self._send(["REQ", self.sub.requests_sub_id, req_filter])
         await self._send(["REQ", self.sub.responses_sub_id, res_filter])
+        # Start EOSE timeout guard
+        self.eose_timeout_task = asyncio.create_task(self._eose_timeout())
 
     async def _on_connection(self, _):
         """
@@ -469,6 +507,10 @@ class NWCServiceProvider:
         #         service connection and do not have a response yet,
         #         are considered stale, we will process them now
         if self.sub.requests_eose and self.sub.responses_eose:
+            # Cancel the EOSE timeout since we got both EOSEs
+            if self.eose_timeout_task:
+                self.eose_timeout_task.cancel()
+                self.eose_timeout_task = None
             stales = self.sub.get_stale()
             for stale in stales:
                 await self._handle_request(stale)
@@ -629,6 +671,12 @@ class NWCServiceProvider:
                 self.info_event_task.cancel()
         except Exception as e:
             logger.warning("Error closing info event loop: " + str(e))
+        # cancel eose timeout
+        try:
+            if self.eose_timeout_task:
+                self.eose_timeout_task.cancel()
+        except Exception as e:
+            logger.warning("Error closing eose timeout task: " + str(e))
         # close the websocket
         try:
             if self.ws:


### PR DESCRIPTION
## Problem

The NWC Service Provider blocks ALL request processing until it receives EOSE (End of Stored Events) for both its subscriptions (kind 23194 and 23195). If EOSE is never received — which can happen if:

- The relay does not send EOSE
- EOSE is lost due to race conditions in the nostrclient router shared state
- The connection drops before EOSE arrives

...the provider silently queues incoming request events but **never processes them**. Client wallets see "all promises rejected" because their NWC calls time out with no response.

Additionally, `handle_missed_events` defaults to `0`, meaning on reconnect the provider only subscribes to events created *after* reconnection. Any requests sent during the disconnect window are permanently lost.

## Changes

### 1. `nwcp.py` — EOSE timeout fallback
- Added `_eose_timeout` method: a 10-second guard that fires if both EOSEs have not arrived
- On timeout: forces both EOSE flags to `True`, processes all queued stale events, and allows future events to be processed in real-time
- If EOSE arrives normally before the timeout, its cancelled
- Added `_process_stale_events` helper for reuse

### 2. `nwcp.py` — Cleanup
- Added `eose_timeout_task` cancellation in `cleanup()` and `_subscribe()`

### 3. `migrations.py`
- Changed default `handle_missed_events` from `0` to `120`
- On reconnect, the provider looks back 2 minutes for missed request events

### 4. `README.md`
- Updated config table to reflect new default

## Testing

Verified that:
- The provider starts processing requests within 10s even without EOSE
- Normal EOSE flow works as before (timeout is cancelled, no behavioral change)
- Reconnection resets the timeout correctly
- Python syntax and imports are valid