### PR TITLE
fix: add state field to lookup_invoice and list_transactions responses

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -363,8 +363,10 @@ async def _on_lookup_invoice(
         "created_at": timestamp,
         "expires_at": expiry,
         "settled_at": timestamp if is_settled else None,
+        "state": "settled" if is_settled else "pending",
         "metadata": {},
     }
+
     if invoice_data.description_hash:
         res["description_hash"] = invoice_data.description_hash
     # await log_nwc(pubkey, payload)
@@ -438,6 +440,7 @@ async def _on_list_transactions(
                 "fees_paid": p.fee,
                 "created_at": timestamp,
                 "settled_at": timestamp if is_settled else None,
+                "state": "settled" if is_settled else "pending",
                 "metadata": {},
             }
         )


### PR DESCRIPTION
Alby Go wallet relies on the `state` field in NWC transaction responses to determine settlement status. Without it, successful transactions display as failed.

Added `"state": "settled" if is_settled else "pending"` to both `_on_lookup_invoice` and `_on_list_transactions`.

Confirmed fixed locally.